### PR TITLE
fix: added box clipping post augmentation to make object training stable

### DIFF
--- a/yolov6/data/datasets.py
+++ b/yolov6/data/datasets.py
@@ -169,6 +169,22 @@ class TrainValDataset(Dataset):
 
         labels_out = torch.zeros((len(labels), 6))
         if len(labels):
+            #normalize before passing to torch with safety margin post augmentation
+            eps = 1e-3
+            
+            x_c, y_c, bw, bh = labels[:, 1], labels[:, 2], labels[:, 3], labels[:, 4]
+
+            x_c = np.clip(x_c, bw / 2 + eps, 1 - bw / 2 - eps)
+            y_c = np.clip(y_c, bh / 2 + eps, 1 - bh / 2 - eps)
+
+            bw = np.clip(bw, eps, 1 - eps)
+            bh = np.clip(bh, eps, 1 - eps)
+
+            labels[:, 1] = x_c
+            labels[:, 2] = y_c
+            labels[:, 3] = bw
+            labels[:, 4] = bh
+
             labels_out[:, 1:] = torch.from_numpy(labels)
 
         # Convert


### PR DESCRIPTION
The original dataloader does not clip bounding boxes after applying general augmentations (e.g., vertical and horizontal flips). As a result, bounding box coordinates can exceed valid ranges, leading to floating-point precision issues. In particular, the computed width (or height) may exceed 1.0, which breaks the assumption of normalized coordinates in [0, 1].

This is mainly observed in the objects dataset, as there are a higher number of bounding boxes towards the edge of the image compared to artefacts datasets.

Issue
When bounding box dimensions exceed 1.0, subsequent GPU operations may fail, causing CUDA runtime errors.

Fix
This PR adds a clipping step after augmentations to ensure bounding boxes remain within [0, 1], preventing invalid coordinates and CUDA errors.